### PR TITLE
windows x64 config support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,9 +2,6 @@
   "targets": [
     {
       "target_name": "node_mmdb",
-      "sources": [
-        "<!@(ls -1 ./src/*.cpp)",
-      ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "deps/config/<(OS)/<(target_arch)",
@@ -24,44 +21,51 @@
       "cflags!":    [ '-fno-exceptions', '-fno-rtti' ],
       "cflags_cc!": [ '-fno-exceptions', '-fno-rtti' ],
       "conditions": [
-          [ 'OS=="mac"', {
-            "xcode_settings": {
-                'OTHER_CPLUSPLUSFLAGS': [
-                  '-std=c++11',
-                  '-stdlib=libc++',
-                  '-Wno-unused-function',
-                  '-Wno-reorder',
-                  '-O3'
-                ],
-                'GCC_ENABLE_CPP_RTTI': 'YES',
-                'OTHER_LDFLAGS': ['-stdlib=libc++'],
-                'MACOSX_DEPLOYMENT_TARGET': '10.7',
-                'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-            }
-        }],
-          [ 'OS=="win"', {
-            "defines": [
-              '_SSIZE_T_DEFINED'
+        [ 'OS=="mac"', {
+          "xcode_settings": {
+            'OTHER_CPLUSPLUSFLAGS': [
+              '-std=c++11',
+              '-stdlib=libc++',
+              '-Wno-unused-function',
+              '-Wno-reorder',
+              '-O3'
             ],
-            "link_settings": {
-                "libraries": [
-                    "-lws2_32.lib",
-                ]
-            },            
-        }]
-
+            'GCC_ENABLE_CPP_RTTI': 'YES',
+            'OTHER_LDFLAGS': ['-stdlib=libc++'],
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+          }
+        }],
+        [ 'OS=="win"', {
+          "sources": [
+            ".\\src\\node_mmdb.cpp",
+          ],
+          "defines": [
+            '_SSIZE_T_DEFINED'
+          ],
+          "link_settings": {
+            "libraries": [
+                "-lws2_32.lib",
+            ],
+          },
+        }],
+        [ 'OS!="win"', {
+          "sources": [
+            "<!@(ls -1 ./src/*.cpp)",
+          ],
+        }],
       ]
     },
     {
-        "target_name": "action_after_build",
-        "type": "none",
-        "dependencies": [ "node_mmdb" ],
-        "copies": [
-            {
-                "files": [ "<(PRODUCT_DIR)/node_mmdb.node" ],
-                "destination": "./lib"
-            }
-        ]
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "node_mmdb" ],
+      "copies": [
+        {
+            "files": [ "<(PRODUCT_DIR)/node_mmdb.node" ],
+            "destination": "./lib"
+        }
+      ]
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,7 +38,18 @@
                 'MACOSX_DEPLOYMENT_TARGET': '10.7',
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
             }
+        }],
+          [ 'OS=="win"', {
+            "defines": [
+              '_SSIZE_T_DEFINED'
+            ],
+            "link_settings": {
+                "libraries": [
+                    "-lws2_32.lib",
+                ]
+            },            
         }]
+
       ]
     },
     {

--- a/deps/config/win/x64/config.h
+++ b/deps/config/win/x64/config.h
@@ -1,0 +1,183 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <assert.h> header file. */
+#define HAVE_ASSERT_H 1
+
+/* Define to 1 if the system has the type `boolean'. */
+/* #undef HAVE_BOOLEAN */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `getpagesize' function. */
+#define HAVE_GETPAGESIZE 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <libgen.h> header file. */
+#define HAVE_LIBGEN_H 1
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
+   to 0 otherwise. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <math.h> header file. */
+#define HAVE_MATH_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have a working `mmap' system call. */
+#define HAVE_MMAP 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#define HAVE_NETDB_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H 1
+
+/* Has an open_memstream() function */
+#define HAVE_OPEN_MEMSTREAM 1
+
+/* Define to 1 if you have the <stdarg.h> header file. */
+#define HAVE_STDARG_H 1
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Missing the unsigned __int128 type */
+#define MMDB_UINT128_IS_BYTE_ARRAY 1
+
+/* int128 types are available with __attribute__((mode(TI))) */
+/* #undef MMDB_UINT128_USING_MODE */
+
+/* Name of package */
+#define PACKAGE "libmaxminddb"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "support@maxmind.com"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libmaxminddb"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libmaxminddb 1.1.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libmaxminddb"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.1.1"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "1.1.1"
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT64_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to rpl_malloc if the replacement function should be used. */
+/* #undef malloc */
+
+/* Define to `long int' if <sys/types.h> does not define. */
+/* #undef off_t */
+
+/* Define to the equivalent of the C99 'restrict' keyword, or to
+   nothing if this is not supported.  Do not define if restrict is
+   supported directly.  */
+#define restrict __restrict
+/* Work around a bug in Sun C++: it does not support _Restrict or
+   __restrict__, even though the corresponding Sun C compiler ends up with
+   "#define restrict _Restrict" or "#define restrict __restrict__" in the
+   previous line.  Perhaps some future version of Sun C++ will work with
+   restrict; if so, hopefully it defines __RESTRICT like Sun C does.  */
+#if defined __SUNPRO_CC && !defined __RESTRICT
+# define _Restrict
+# define __restrict__
+#endif
+
+/* Windows supports ssize_t so don't let maxminddb.h redefine it */
+#define _SSIZE_T_DEFINED 1
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef ssize_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */

--- a/deps/config/win/x64/maxminddb_config.h
+++ b/deps/config/win/x64/maxminddb_config.h
@@ -1,0 +1,17 @@
+/* include/maxminddb_config.h.  Generated from maxminddb_config.h.in by configure.  */
+#ifndef MAXMINDDB_CONFIG_H
+#define MAXMINDDB_CONFIG_H
+
+#ifndef MMDB_UINT128_USING_MODE
+/* Define as 1 if we we use unsigned int __atribute__ ((__mode__(TI))) for uint128 values */
+#define MMDB_UINT128_USING_MODE 0
+#endif
+
+#ifndef MMDB_UINT128_IS_BYTE_ARRAY
+/* Define as 1 if we don't have an unsigned __int128 type */
+#define MMDB_UINT128_IS_BYTE_ARRAY 1
+#endif
+
+#undef _MSVC_VER
+
+#endif                          /* MAXMINDDB_CONFIG_H */


### PR DESCRIPTION
Configs to build node-geoip2 on Windows.
Compiled on Windows 10 with Visual Studio 2013 & node-gyp@3.3.1
Tested with node@4.3.0 on the same environment.
