### PR TITLE
Add process.platform restriction to prevent install on incompatible p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "nan": "2.3.5"
   },
+  "os" : [ "darwin", "linux" ],
   "devDependencies": {
     "mocha": "^2.5.1",
     "chai": "^3.5.0"


### PR DESCRIPTION
…latforms.

We've been having an issue where our production systems are on linux, some of the team development Mac OSX and some on Windows PCs. This module has issues installing and working on Windows machines so we get errors when trying to npm install. We can't set it as an optional dependecy as it's needed for production.

This flag will prevent the module from being installed where it should