### PR TITLE
patch for workaround for compatability with XCode9 + node 8.6.0

### DIFF
--- a/deps/config/mac/x64/maxminddb_config.h
+++ b/deps/config/mac/x64/maxminddb_config.h
@@ -11,5 +11,8 @@
 /* Define as 1 if we don't have an unsigned __int128 type */
 #define MMDB_UINT128_IS_BYTE_ARRAY 0
 #endif
+typedef __darwin_mach_port_t mach_port_t
+#include <pthread.h>
+mach_port_t pthread_mach_thread_np(pthread_t)
 
 #endif                          /* MAXMINDDB_CONFIG_H */


### PR DESCRIPTION
v1.0.5 of this module will not compile correctly with XCode 9 installed, which is the default for Mac OSX High Sierra.  This workaround is successfully being used in other projects, for example Apache Arrow.  I have tested it locally using Mac OSX Sierra with XCode 9 and node 8.6.0.

Please merge this at your earliest convenience.  Every time I do an install of package.json, it pulls this from npmjs.org and I must manually find the cached version and edit the file.

Note that I have only tested this on a Mac with XCode 9.  I have not tested it on any other OS or compiler version.  Perhaps these 3 lines could be in an #ifdef in the mac/x64 specifig config files.