### PR TITLE
Workaround for node-gyp failure

### DIFF
--- a/deps/config/mac/x64/maxminddb_config.h
+++ b/deps/config/mac/x64/maxminddb_config.h
@@ -11,5 +11,8 @@
 /* Define as 1 if we don't have an unsigned __int128 type */
 #define MMDB_UINT128_IS_BYTE_ARRAY 0
 #endif
+typedef __darwin_mach_port_t mach_port_t
+#include <pthread.h>
+mach_port_t pthread_mach_thread_np(pthread_t)
 
 #endif                          /* MAXMINDDB_CONFIG_H */

--- a/deps/config/mac/x64/maxminddb_config.h
+++ b/deps/config/mac/x64/maxminddb_config.h
@@ -11,8 +11,8 @@
 /* Define as 1 if we don't have an unsigned __int128 type */
 #define MMDB_UINT128_IS_BYTE_ARRAY 0
 #endif
-typedef __darwin_mach_port_t mach_port_t
+typedef __darwin_mach_port_t mach_port_t;
 #include <pthread.h>
-mach_port_t pthread_mach_thread_np(pthread_t)
+mach_port_t pthread_mach_thread_np(pthread_t);
 
 #endif                          /* MAXMINDDB_CONFIG_H */

--- a/deps/config/mac/x64/maxminddb_config.h
+++ b/deps/config/mac/x64/maxminddb_config.h
@@ -11,6 +11,8 @@
 /* Define as 1 if we don't have an unsigned __int128 type */
 #define MMDB_UINT128_IS_BYTE_ARRAY 0
 #endif
+#include <sys/_types.h> /* __darwin_mach_port_t */
+
 typedef __darwin_mach_port_t mach_port_t;
 #include <pthread.h>
 mach_port_t pthread_mach_thread_np(pthread_t);


### PR DESCRIPTION
This works for me on Sierra 10.12.6 with command line tools installed and node 6.9.1 . 
Based on the other PR from DonaldFoss but with semicolons and an extra include.