### PR TITLE
Upgrade nan to 2.10+ for node 10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git://github.com/davidtsai/node-geoip2.git"
   },
   "dependencies": {
-    "nan": "2.3.5"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "mocha": "^2.5.1",


### PR DESCRIPTION
Upgrade nan to 2.10+ so node-geoip2 could build in node 10.

Otherwise, will encounter the following error:
```
  CXX(target) Release/obj.target/unix_dgram/src/unix_dgram.o
In file included from ../src/unix_dgram.cc:5:
In file included from ../../nan/nan.h:190:
../../nan/nan_maybe_43_inl.h:88:15: error: no member named 'ForceSet' in 'v8::Object'
  return obj->ForceSet(GetCurrentContext(), key, value, attribs);
         ~~~  ^
```
See: https://github.com/nodejs/nan/issues/763

